### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ To install them on Arch Linux:
 
     sudo pacman -S sdl_mixer ncurses
 
-To install them on Ubuntu, I think this will work (but untested):
+To install them on Ubuntu:
 
-    sudo apt-get install libsdl-mixer-1.2-dev libncurses5-dev
+    sudo apt-get install libsdl-mixer1.2-dev libncurses5-dev
 
 To compile:
 


### PR DESCRIPTION
Just tested installing on Ubuntu, worked fine with an updated version of installing the dependencies...

The package for SDL mixer is [libsdl-mixer1.2-dev](http://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=libsdl-mixer1.2-dev&searchon=names) in the Ubuntu repos. See the commit log.
